### PR TITLE
Opt-in hardening: MQTT secrets, fan-control failsafe, SSH host-key verification, headless mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,14 @@ Instead of using a password, you can configure SSH key authentication for more s
 
 The integration will automatically detect and use the SSH key.
 
+### SSH Host Key Verification (Optional)
+
+By default the SSH connection to the NAS does not verify the host key. If you'd like the integration to verify it, enable **Verify SSH host key** during setup (or reconfigure). On the first successful connection the NAS host key is recorded (trust-on-first-use) and stored with the config entry; every connection afterwards is checked against it, so a man-in-the-middle that presents a different key is rejected.
+
+Alternatively, you can point **SSH known_hosts file** at a `known_hosts` file on the Home Assistant host (for example one you manage yourself); when set, it is used to verify the host key and takes precedence over trust-on-first-use.
+
+If the NAS host key legitimately changes (for example after a firmware reinstall), remove and re-add the integration - or clear the stored key - so a new key can be pinned. Both options are off/blank by default, preserving the current behavior.
+
 ### Secure MQTT (TLS) (Optional)
 
 If your MQTT broker is configured for TLS (e.g., port 8883), enable the **Use TLS** toggle during setup. After submitting the main form, you'll be prompted for:
@@ -237,6 +245,26 @@ If your MQTT broker is configured for TLS (e.g., port 8883), enable the **Use TL
 - **Allow untrusted certificate** - enable if your broker uses a self-signed certificate
 
 This applies to both the config flow connection test and the on-device scripts deployed to your UNAS. The standard plaintext setup (port 1883) requires no changes, just leave **Use TLS** off.
+
+### Externalizing MQTT Credentials (Optional)
+
+By default, the MQTT credentials are written directly into the monitoring scripts that are deployed to the NAS (`/root/unas_monitor.py`, `/root/fan_control.sh`). If you'd rather keep the MQTT password out of those on-device script bodies - for example because you manage secrets with a password manager or an env file - you can supply a **credentials file** instead.
+
+**How it works:**
+
+1. Create a root-readable env file on the Home Assistant host (for example under `/share`), defining at least the MQTT username and password:
+   ```bash
+   # /share/unifi_unas/mqtt.env
+   MQTT_USER=your_mqtt_user
+   MQTT_PASS=your_mqtt_password
+   ```
+   You may also override any other setting the scripts read: `MQTT_HOST`, `MQTT_PORT`, `MQTT_TLS`, `MQTT_TLS_INSECURE`, `MQTT_ROOT`.
+
+2. Enter that path in the **MQTT credentials file** field during setup (or reconfigure).
+
+When set, the integration uploads that file to a root-only (`chmod 600`) file on the NAS (`/root/.unas_monitor.env`) and the systemd services load it via `EnvironmentFile=`. The scripts read the MQTT settings from the environment, so the username and password are no longer inlined into the deployed script bodies. Any value not provided by the env file falls back to what you entered in the integration.
+
+Leave the field blank for the standard setup (credentials are written into the scripts as before).
 
 ## Fan Control Modes
 
@@ -315,6 +343,16 @@ change, depending on your environment and targets.
 
 Lock fans to a fixed speed (0-100%). Use the Fan Speed slider to set the desired speed.
 
+### Fan Safety / Failsafe
+
+Whenever the fan-control daemon isn't actively driving the fans, control is handed back to the NAS firmware so the drives are never left under a stale fan speed:
+
+- When the daemon stops, crashes, or is disabled, a systemd `ExecStopPost` hook (and the script's own exit handler) restores every fan channel to automatic mode (`pwmN_enable=2`).
+- The daemon explicitly takes manual control (`pwmN_enable=1`) when it writes a PWM value, and hands control back to automatic when you switch to **UNAS Managed** mode.
+- A systemd watchdog (`WatchdogSec`) restarts the daemon if it hangs, rather than leaving a frozen PWM in place.
+
+**Minimum fan PWM floor (optional):** you can set a **Minimum fan PWM floor** (0-255, `0` disables it) in the integration options. When set, it is enforced in every actively-controlled mode (Custom Curve, Target Temperature, Set Speed), so a misconfigured curve or a low set speed can't drive the fans below a safe ratio. It does not apply to **UNAS Managed** mode, where the firmware controls the fans.
+
 ## Troubleshooting
 
 ### Scripts Not Installing
@@ -370,6 +408,26 @@ Removing the integration fully restores your UNAS to stock. The cleanup process:
 No manual cleanup is required.
 
 ## Advanced
+
+<details>
+<summary><strong>Headless collector (--once --json)</strong></summary>
+
+The monitor script can run a single collection cycle and print the full metric set as JSON, without connecting to MQTT. This is handy for troubleshooting, testing, and external consumers that want the same data over SSH:
+
+```bash
+ssh root@YOUR_UNAS_IP "python3 /root/unas_monitor.py --once --json"
+```
+
+It prints a JSON object with `system`, `hdd`, `nvme`, `pools`, and (on non-UNVR devices) `smb`, `nfs`, and `shares`, then exits. No MQTT connection is made and the fan-control shared temp file is not touched.
+
+</details>
+
+<details>
+<summary><strong>Monitoring-only / independent services</strong></summary>
+
+The two on-device services can be deployed independently via the **Enable monitoring service** and **Enable fan-control service** options (both on by default). Turning **Enable fan-control service** off gives you a monitoring-only install: the fan-control script is not deployed to the NAS and the fans stay fully UNAS-managed. Toggling a service off later stops, disables, and removes it on the next reload (and hands the fans back to firmware control when fan-control is disabled).
+
+</details>
 
 <details>
 <summary><strong>MQTT Topics</strong></summary>

--- a/custom_components/unifi_unas/__init__.py
+++ b/custom_components/unifi_unas/__init__.py
@@ -27,10 +27,18 @@ from .const import (
     CONF_MQTT_PORT,
     CONF_MQTT_TLS,
     CONF_MQTT_TLS_INSECURE,
+    CONF_CREDENTIALS_FILE,
+    CONF_MIN_PWM_FLOOR,
+    CONF_VERIFY_HOST_KEY,
+    CONF_KNOWN_HOSTS,
+    CONF_HOST_KEY,
+    CONF_ENABLE_MONITOR,
+    CONF_ENABLE_FAN_CONTROL,
     CONF_SCAN_INTERVAL,
     CONF_DEVICE_MODEL,
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_DEVICE_MODEL,
+    DEFAULT_MIN_PWM_FLOOR,
     DEFAULT_MQTT_PORT,
     get_mqtt_root,
     get_mqtt_topics,
@@ -166,6 +174,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         mqtt_port=entry.data.get(CONF_MQTT_PORT, DEFAULT_MQTT_PORT),
         mqtt_tls=entry.data.get(CONF_MQTT_TLS, False),
         mqtt_tls_insecure=entry.data.get(CONF_MQTT_TLS_INSECURE, False),
+        credentials_file=entry.data.get(CONF_CREDENTIALS_FILE),
+        min_pwm_floor=entry.data.get(CONF_MIN_PWM_FLOOR, DEFAULT_MIN_PWM_FLOOR),
+        verify_host_key=entry.data.get(CONF_VERIFY_HOST_KEY, False),
+        known_hosts_path=entry.data.get(CONF_KNOWN_HOSTS),
+        pinned_host_key=entry.data.get(CONF_HOST_KEY),
+        enable_monitor=entry.data.get(CONF_ENABLE_MONITOR, True),
+        enable_fan_control=entry.data.get(CONF_ENABLE_FAN_CONTROL, True),
     )
 
     integration = await async_get_integration(hass, DOMAIN)
@@ -180,6 +195,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await manager.connect()
         ssh_connected = True
         _LOGGER.info("SSH connection established to %s", entry.data[CONF_HOST])
+
+        # Trust-on-first-use: when host-key verification is enabled and no key
+        # has been pinned yet, record the key seen on this first connection so
+        # subsequent connections are verified against it.
+        if (
+            entry.data.get(CONF_VERIFY_HOST_KEY)
+            and not entry.data.get(CONF_HOST_KEY)
+            and manager.server_host_key
+        ):
+            new_data = dict(entry.data)
+            new_data[CONF_HOST_KEY] = manager.server_host_key
+            hass.config_entries.async_update_entry(entry, data=new_data)
+            manager.pinned_host_key = manager.server_host_key
+            _LOGGER.info("Pinned SSH host key for %s", entry.data[CONF_HOST])
 
         scripts_installed = await manager.scripts_installed()
         if last_deploy_version != current_version or not scripts_installed or is_dev_version:

--- a/custom_components/unifi_unas/config_flow.py
+++ b/custom_components/unifi_unas/config_flow.py
@@ -29,6 +29,8 @@ from .const import (
     DEFAULT_DEVICE_MODEL,
     DEFAULT_MQTT_PORT,
     DEFAULT_MQTT_TLS_PORT,
+    DEFAULT_MIN_PWM_FLOOR,
+    MAX_PWM,
     MIN_SCAN_INTERVAL,
     MAX_SCAN_INTERVAL,
     CONF_MQTT_HOST,
@@ -37,6 +39,12 @@ from .const import (
     CONF_MQTT_PORT,
     CONF_MQTT_TLS,
     CONF_MQTT_TLS_INSECURE,
+    CONF_CREDENTIALS_FILE,
+    CONF_MIN_PWM_FLOOR,
+    CONF_VERIFY_HOST_KEY,
+    CONF_KNOWN_HOSTS,
+    CONF_ENABLE_MONITOR,
+    CONF_ENABLE_FAN_CONTROL,
     CONF_SCAN_INTERVAL,
     CONF_DEVICE_MODEL,
     CONF_DEVICE_NAME,
@@ -63,6 +71,14 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
             )
         ),
         vol.Optional(CONF_DEVICE_NAME, default="UNAS"): str,
+        vol.Optional(CONF_CREDENTIALS_FILE): str,
+        vol.Optional(CONF_VERIFY_HOST_KEY, default=False): BooleanSelector(),
+        vol.Optional(CONF_KNOWN_HOSTS): str,
+        vol.Optional(CONF_ENABLE_MONITOR, default=True): BooleanSelector(),
+        vol.Optional(CONF_ENABLE_FAN_CONTROL, default=True): BooleanSelector(),
+        vol.Optional(CONF_MIN_PWM_FLOOR, default=DEFAULT_MIN_PWM_FLOOR): NumberSelector(
+            NumberSelectorConfig(min=0, max=MAX_PWM, mode=NumberSelectorMode.BOX)
+        ),
         vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): NumberSelector(
             NumberSelectorConfig(
                 min=MIN_SCAN_INTERVAL, max=MAX_SCAN_INTERVAL, mode=NumberSelectorMode.BOX
@@ -91,7 +107,8 @@ class UNASProConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if new_model != old_model:
                 errors["base"] = "model_changed"
             elif error_key := await self._test_ssh(user_input[CONF_HOST], user_input[CONF_USERNAME],
-                                                   user_input.get(CONF_PASSWORD)):
+                                                   user_input.get(CONF_PASSWORD),
+                                                   user_input.get(CONF_KNOWN_HOSTS)):
                 errors["base"] = error_key
             elif user_input.get(CONF_MQTT_TLS):
                 self._pending_input = user_input
@@ -133,6 +150,32 @@ class UNASProConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     CONF_DEVICE_NAME,
                     default=entry.data.get(CONF_DEVICE_NAME) or "UNAS",
                 ): str,
+                vol.Optional(
+                    CONF_CREDENTIALS_FILE,
+                    default=entry.data.get(CONF_CREDENTIALS_FILE) or "",
+                ): str,
+                vol.Optional(
+                    CONF_VERIFY_HOST_KEY,
+                    default=entry.data.get(CONF_VERIFY_HOST_KEY, False),
+                ): BooleanSelector(),
+                vol.Optional(
+                    CONF_KNOWN_HOSTS,
+                    default=entry.data.get(CONF_KNOWN_HOSTS) or "",
+                ): str,
+                vol.Optional(
+                    CONF_ENABLE_MONITOR,
+                    default=entry.data.get(CONF_ENABLE_MONITOR, True),
+                ): BooleanSelector(),
+                vol.Optional(
+                    CONF_ENABLE_FAN_CONTROL,
+                    default=entry.data.get(CONF_ENABLE_FAN_CONTROL, True),
+                ): BooleanSelector(),
+                vol.Optional(
+                    CONF_MIN_PWM_FLOOR,
+                    default=entry.data.get(CONF_MIN_PWM_FLOOR, DEFAULT_MIN_PWM_FLOOR),
+                ): NumberSelector(
+                    NumberSelectorConfig(min=0, max=MAX_PWM, mode=NumberSelectorMode.BOX)
+                ),
                 vol.Optional(CONF_SCAN_INTERVAL,
                              default=entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)): NumberSelector(
                     NumberSelectorConfig(min=MIN_SCAN_INTERVAL, max=MAX_SCAN_INTERVAL, mode=NumberSelectorMode.BOX)
@@ -201,7 +244,8 @@ class UNASProConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             if error_key := await self._test_ssh(user_input[CONF_HOST], user_input[CONF_USERNAME],
-                                                 user_input.get(CONF_PASSWORD)):
+                                                 user_input.get(CONF_PASSWORD),
+                                                 user_input.get(CONF_KNOWN_HOSTS)):
                 errors["base"] = error_key
             elif user_input.get(CONF_MQTT_TLS):
                 self._pending_input = user_input
@@ -258,7 +302,10 @@ class UNASProConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         })
         return self.async_show_form(step_id="mqtt_tls", data_schema=schema, errors=errors)
 
-    async def _test_ssh(self, host: str, username: str, password: str | None) -> str | None:
+    async def _test_ssh(
+        self, host: str, username: str, password: str | None,
+        known_hosts_path: str | None = None,
+    ) -> str | None:
         try:
             client_keys = None
             if not password:
@@ -274,7 +321,7 @@ class UNASProConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     username=username,
                     password=password if password else None,
                     client_keys=client_keys,
-                    known_hosts=None,
+                    known_hosts=known_hosts_path or None,
                 ),
                 timeout=10.0,
             )

--- a/custom_components/unifi_unas/const.py
+++ b/custom_components/unifi_unas/const.py
@@ -20,7 +20,39 @@ CONF_MQTT_PASSWORD = "mqtt_password"
 CONF_MQTT_PORT = "mqtt_port"
 CONF_MQTT_TLS = "mqtt_tls"
 CONF_MQTT_TLS_INSECURE = "mqtt_tls_insecure"
+CONF_CREDENTIALS_FILE = "credentials_file"
+CONF_MIN_PWM_FLOOR = "min_pwm_floor"
+CONF_VERIFY_HOST_KEY = "verify_host_key"
+CONF_KNOWN_HOSTS = "known_hosts"
+CONF_HOST_KEY = "host_key"
+CONF_ENABLE_MONITOR = "enable_monitor"
+CONF_ENABLE_FAN_CONTROL = "enable_fan_control"
 CONF_SCAN_INTERVAL = "scan_interval"
+
+DEFAULT_MIN_PWM_FLOOR = 0
+MAX_PWM = 255
+
+# On-device root-only env file that supplies MQTT settings to the monitor and
+# fan-control services via systemd EnvironmentFile=. Used by the optional
+# credentials_file delivery path so secrets need not be inlined into the
+# deployed scripts.
+UNAS_ENV_FILE = "/root/.unas_monitor.env"
+
+# MQTT settings the on-device env file may supply (env var name on the NAS).
+# The scripts read these from the environment, falling back to any value baked
+# in at deploy time when the variable is unset.
+ENV_MQTT_KEYS = (
+    "MQTT_HOST",
+    "MQTT_USER",
+    "MQTT_PASS",
+    "MQTT_ROOT",
+    "MQTT_PORT",
+    "MQTT_TLS",
+    "MQTT_TLS_INSECURE",
+)
+# The subset that is sensitive and must not be inlined into script bodies when
+# the env-file delivery path is active.
+ENV_MQTT_SECRET_KEYS = ("MQTT_USER", "MQTT_PASS")
 
 DEFAULT_MQTT_PORT = 1883
 DEFAULT_MQTT_TLS_PORT = 8883

--- a/custom_components/unifi_unas/scripts/fan_control.service
+++ b/custom_components/unifi_unas/scripts/fan_control.service
@@ -4,7 +4,12 @@ After=network-online.target unas_monitor.service
 Wants=network-online.target
 
 [Service]
+EnvironmentFile=-/root/.unas_monitor.env
+Type=notify
+NotifyAccess=all
+WatchdogSec=120
 ExecStart=/root/fan_control.sh --service
+ExecStopPost=/bin/sh -c 'for e in /sys/class/hwmon/hwmon0/pwm*_enable; do [ -w "$e" ] && echo 2 > "$e"; done'
 Restart=always
 RestartSec=30
 User=root

--- a/custom_components/unifi_unas/scripts/fan_control.sh
+++ b/custom_components/unifi_unas/scripts/fan_control.sh
@@ -23,6 +23,16 @@ SYMMETRIC_DECAY=true
 # Configuration (replaced at deploy time)
 # =============================================================================
 
+# Capture any MQTT settings provided via the environment (e.g. a systemd
+# EnvironmentFile) before the deploy-time defaults below overwrite them.
+_ENV_MQTT_HOST="${MQTT_HOST:-}"
+_ENV_MQTT_USER="${MQTT_USER:-}"
+_ENV_MQTT_PASS="${MQTT_PASS:-}"
+_ENV_MQTT_ROOT="${MQTT_ROOT:-}"
+_ENV_MQTT_PORT="${MQTT_PORT:-}"
+_ENV_MQTT_TLS="${MQTT_TLS:-}"
+_ENV_MQTT_TLS_INSECURE="${MQTT_TLS_INSECURE:-}"
+
 MQTT_HOST="REPLACE_ME"
 MQTT_USER="REPLACE_ME"
 MQTT_PASS="REPLACE_ME"
@@ -30,6 +40,19 @@ MQTT_ROOT="REPLACE_ME"
 MQTT_PORT="REPLACE_ME"
 MQTT_TLS="REPLACE_ME"
 MQTT_TLS_INSECURE="REPLACE_ME"
+
+# Environment values take precedence over the deploy-time defaults above. This
+# lets the integration supply MQTT settings via a root-only EnvironmentFile
+# (see credentials_file) instead of inlining secrets into this script. When a
+# variable is unset the deploy-time value is kept, so default behavior is
+# unchanged.
+MQTT_HOST="${_ENV_MQTT_HOST:-$MQTT_HOST}"
+MQTT_USER="${_ENV_MQTT_USER:-$MQTT_USER}"
+MQTT_PASS="${_ENV_MQTT_PASS:-$MQTT_PASS}"
+MQTT_ROOT="${_ENV_MQTT_ROOT:-$MQTT_ROOT}"
+MQTT_PORT="${_ENV_MQTT_PORT:-$MQTT_PORT}"
+MQTT_TLS="${_ENV_MQTT_TLS:-$MQTT_TLS}"
+MQTT_TLS_INSECURE="${_ENV_MQTT_TLS_INSECURE:-$MQTT_TLS_INSECURE}"
 
 MQTT_TLS_OPTS=""
 if [ "$MQTT_TLS" = "true" ]; then
@@ -42,6 +65,11 @@ fi
 MQTT_SYSTEM="${MQTT_ROOT}/system"
 MQTT_CONTROL="${MQTT_ROOT}/control"
 MQTT_FAN="${MQTT_CONTROL}/fan"
+
+# Optional global minimum PWM floor (0 = disabled), enforced in every actively
+# controlled mode so a misconfiguration can't drive the fans below a safe
+# ratio. Set at deploy time from the integration config.
+MIN_PWM_FLOOR="0"
 
 STATE_FILE="/tmp/fan_control_state"
 LAST_PWM_FILE="/tmp/fan_control_last_pwm"
@@ -108,6 +136,15 @@ log() {
     echo "$msg" >> "$LOG_FILE"
 }
 
+# Notify systemd of readiness/liveness when run under a Type=notify unit with
+# WatchdogSec. No-ops when not managed by systemd (NOTIFY_SOCKET unset) or when
+# the systemd-notify helper is unavailable, so manual runs are unaffected.
+notify_systemd() {
+    [ -n "${NOTIFY_SOCKET:-}" ] || return 0
+    command -v systemd-notify >/dev/null 2>&1 || return 0
+    systemd-notify "$@" 2>/dev/null || true
+}
+
 # =============================================================================
 # Utility functions
 # =============================================================================
@@ -150,10 +187,32 @@ for _pwm in /sys/class/hwmon/hwmon0/pwm[1-9]; do
     [ -w "$_pwm" ] && PWM_CHANNELS+=("$_pwm")
 done
 
+# Matching pwmN_enable channels (1 = manual control, 2 = automatic/chip-managed).
+PWM_ENABLE_CHANNELS=()
+for _pwm in "${PWM_CHANNELS[@]:-}"; do
+    [ -n "$_pwm" ] && PWM_ENABLE_CHANNELS+=("${_pwm}_enable")
+done
+
+# Write an enable mode to every writable pwmN_enable channel.
+set_pwm_enable() {
+    local ch
+    for ch in "${PWM_ENABLE_CHANNELS[@]:-}"; do
+        [ -n "$ch" ] && [ -w "$ch" ] && echo "$1" > "$ch" 2>/dev/null || true
+    done
+}
+
 set_pwm() {
+    local value="$1"
+    # Enforce the optional global minimum PWM floor regardless of curve/mode.
+    if is_integer "${MIN_PWM_FLOOR:-0}" && [ "${MIN_PWM_FLOOR:-0}" -gt 0 ] \
+       && is_integer "$value" && [ "$value" -lt "$MIN_PWM_FLOOR" ]; then
+        value="$MIN_PWM_FLOOR"
+    fi
+    # Take manual control so the writes below are honored by the controller.
+    set_pwm_enable 1
     local ch
     for ch in "${PWM_CHANNELS[@]:-}"; do
-        [ -n "$ch" ] && echo "$1" > "$ch"
+        [ -n "$ch" ] && echo "$value" > "$ch"
     done
 }
 
@@ -224,6 +283,9 @@ publish_if_changed() {
 
 cleanup() {
     kill "$MQTT_PID" 2>/dev/null || true
+    # Hand the fans back to automatic/firmware control so a stale manual PWM is
+    # never left frozen on the fans if this daemon exits.
+    set_pwm_enable 2
 }
 
 # =============================================================================
@@ -500,6 +562,13 @@ handle_mode_transition() {
         SAVED_PI_INTEGRAL=""
     fi
 
+    # Leaving an actively-controlled mode for unas_managed: hand the fans back
+    # to automatic/firmware control so the last manual PWM isn't left frozen.
+    if [ "$FAN_MODE" = "unas_managed" ] && [ "$PREV_FAN_MODE" != "unas_managed" ]; then
+        set_pwm_enable 2
+        log "MODE SWITCH: Restored automatic fan control (pwm*_enable=2)"
+    fi
+
     PREV_FAN_MODE="$FAN_MODE"
 }
 
@@ -663,6 +732,10 @@ SERVICE=false
 rotate_log_if_needed
 log "Fan control service starting..."
 
+# Signal readiness early so a Type=notify unit doesn't hit its start timeout
+# during the MQTT state fetch below; WatchdogSec supervision starts from here.
+notify_systemd --ready
+
 # Fetch retained MQTT messages on startup (retry up to 30 times every 2 seconds)
 log "Fetching MQTT state..."
 MQTT_OUTPUT=""
@@ -731,6 +804,7 @@ trap cleanup EXIT TERM INT
 if $SERVICE; then
     while true; do
         set_fan_speed
+        notify_systemd WATCHDOG=1
         sleep 1
     done
 else

--- a/custom_components/unifi_unas/scripts/unas_monitor.py
+++ b/custom_components/unifi_unas/scripts/unas_monitor.py
@@ -3,6 +3,7 @@
 import time
 import subprocess
 import logging
+import os
 import json
 import fcntl
 import http.client
@@ -24,6 +25,19 @@ MQTT_ROOT = "REPLACE_ME"
 MQTT_PORT = "REPLACE_ME"
 MQTT_TLS = "REPLACE_ME"
 MQTT_TLS_INSECURE = "REPLACE_ME"
+
+# Environment overrides take precedence over any values baked in above at
+# deploy time. This lets the integration supply MQTT settings via a root-only
+# systemd EnvironmentFile (see credentials_file) instead of inlining secrets
+# into this script. When a variable is unset the deploy-time value is kept, so
+# the default behavior is unchanged.
+MQTT_HOST = os.environ.get("MQTT_HOST", MQTT_HOST)
+MQTT_USER = os.environ.get("MQTT_USER", MQTT_USER)
+MQTT_PASS = os.environ.get("MQTT_PASS", MQTT_PASS)
+MQTT_ROOT = os.environ.get("MQTT_ROOT", MQTT_ROOT)
+MQTT_PORT = os.environ.get("MQTT_PORT", MQTT_PORT)
+MQTT_TLS = os.environ.get("MQTT_TLS", MQTT_TLS)
+MQTT_TLS_INSECURE = os.environ.get("MQTT_TLS_INSECURE", MQTT_TLS_INSECURE)
 DEFAULT_MONITOR_INTERVAL = 30
 MQTT_AVAILABILITY = f"{MQTT_ROOT}/availability"
 MQTT_SYSTEM = f"{MQTT_ROOT}/system"
@@ -100,36 +114,40 @@ ATA_TO_BAY = BAY_MAPPINGS.get(DEVICE_MODEL)
 
 
 class UNASMonitor:
-    def __init__(self):
-        self.mqtt = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2)
-        self.mqtt.username_pw_set(MQTT_USER, MQTT_PASS)
-        if MQTT_TLS == "true":
-            import ssl
-            if MQTT_TLS_INSECURE == "true":
-                self.mqtt.tls_set(cert_reqs=ssl.CERT_NONE)
-                self.mqtt.tls_insecure_set(True)
-            else:
-                self.mqtt.tls_set()
-        self.mqtt.on_connect = self._on_connect
-        self.mqtt.on_disconnect = self._on_disconnect
-        self.mqtt.on_message = self._on_message
+    def __init__(self, mqtt_enabled=True):
+        self.mqtt_enabled = mqtt_enabled
+        self.mqtt = None
         self._connected = False
         self.monitor_interval = DEFAULT_MONITOR_INTERVAL
 
-        self.mqtt.will_set(MQTT_AVAILABILITY, "offline", retain=True)
-        self.mqtt.loop_start()
-        try:
-            self.mqtt.connect(MQTT_HOST, int(MQTT_PORT), 60)
-        except Exception as e:
-            logger.warning(f"Initial MQTT connect failed (will retry): {e}")
+        if mqtt_enabled:
+            self.mqtt = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2)
+            self.mqtt.username_pw_set(MQTT_USER, MQTT_PASS)
+            if MQTT_TLS == "true":
+                import ssl
+                if MQTT_TLS_INSECURE == "true":
+                    self.mqtt.tls_set(cert_reqs=ssl.CERT_NONE)
+                    self.mqtt.tls_insecure_set(True)
+                else:
+                    self.mqtt.tls_set()
+            self.mqtt.on_connect = self._on_connect
+            self.mqtt.on_disconnect = self._on_disconnect
+            self.mqtt.on_message = self._on_message
 
-        for _ in range(30):
-            if self._connected:
-                break
-            time.sleep(1)
+            self.mqtt.will_set(MQTT_AVAILABILITY, "offline", retain=True)
+            self.mqtt.loop_start()
+            try:
+                self.mqtt.connect(MQTT_HOST, int(MQTT_PORT), 60)
+            except Exception as e:
+                logger.warning(f"Initial MQTT connect failed (will retry): {e}")
 
-        if not self._connected:
-            logger.warning("MQTT not connected after 30s - will keep retrying in background")
+            for _ in range(30):
+                if self._connected:
+                    break
+                time.sleep(1)
+
+            if not self._connected:
+                logger.warning("MQTT not connected after 30s - will keep retrying in background")
 
         self._admin_uid = None
         self._api_warned = False
@@ -608,7 +626,10 @@ class UNASMonitor:
 
         self.previous_drive_map = current_drive_map
         drive_temps = [d['temperature'] for d in drives if d.get('temperature', 0) > 0]
-        self.write_hdd_temps(drive_temps if drive_temps else [0])
+        # Only maintain the shared temp file (read by the fan-control daemon)
+        # when running as the live service, not during a one-shot collection.
+        if self.mqtt_enabled:
+            self.write_hdd_temps(drive_temps if drive_temps else [0])
         return drives
 
     def get_nvme_drives(self):
@@ -835,6 +856,59 @@ class UNASMonitor:
             f"R: {system['disk_read']} MB/s W: {system['disk_write']} MB/s"
         )
 
+    def collect(self) -> dict:
+        """Gather the full metric set as a structured dict (no MQTT required).
+
+        This reuses the same collector methods as the live publish path and is
+        used by the headless `--once --json` mode for troubleshooting, tests,
+        and external consumers.
+        """
+        data: dict = {}
+        data["system"] = self.get_system_metrics()
+
+        hdd = {}
+        for drive in self.get_drives():
+            d = dict(drive)
+            hdd[d.pop("bay")] = d
+        data["hdd"] = hdd
+
+        nvme = {}
+        for n in self.get_nvme_drives():
+            d = dict(n)
+            nvme[d.pop("slot")] = d
+        data["nvme"] = nvme
+
+        pools = {}
+        for pool in self.get_pools_from_api():
+            d = dict(pool)
+            pools[d.pop("pool")] = d
+        data["pools"] = pools
+
+        # UNVR doesn't have SMB/NFS/shares
+        if not DEVICE_MODEL.startswith("UNVR"):
+            smb_connections = self.get_smb_connections()
+            smb_shares = self.get_smb_shares()
+            clients = []
+            for share in smb_shares:
+                conn = smb_connections.get(share['pid'], {})
+                clients.append({
+                    'username': conn.get('username', 'unknown'),
+                    'ip': share['ip'],
+                    'share': share['share'],
+                })
+            data["smb"] = {"connections": len(smb_shares), "clients": clients}
+
+            nfs_mounts = self.get_nfs_mounts()
+            data["nfs"] = {"mounts": len(nfs_mounts), "clients": nfs_mounts}
+
+            shares = {}
+            for share in self.get_shares():
+                d = dict(share)
+                shares[d.pop("name")] = d
+            data["shares"] = shares
+
+        return data
+
     def run(self):
         logger.info(f"UNAS monitor started (interval: {self.monitor_interval}s)")
         
@@ -854,6 +928,28 @@ class UNASMonitor:
             time.sleep(self.monitor_interval)
 
 
-if __name__ == '__main__':
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(description="UniFi UNAS monitor")
+    parser.add_argument(
+        "--once", action="store_true",
+        help="Run a single collection cycle and exit, without connecting to MQTT.",
+    )
+    parser.add_argument(
+        "--json", action="store_true",
+        help="Print the collected metrics as JSON to stdout (implies --once).",
+    )
+    args = parser.parse_args()
+
+    if args.once or args.json:
+        monitor = UNASMonitor(mqtt_enabled=False)
+        data = monitor.collect()
+        print(json.dumps(data, indent=2, default=str))
+        return
+
     monitor = UNASMonitor()
     monitor.run()
+
+
+if __name__ == '__main__':
+    main()

--- a/custom_components/unifi_unas/scripts/unas_monitor.service
+++ b/custom_components/unifi_unas/scripts/unas_monitor.service
@@ -4,6 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
+EnvironmentFile=-/root/.unas_monitor.env
 ExecStart=/usr/bin/python3 /root/unas_monitor.py
 Restart=always
 RestartSec=30

--- a/custom_components/unifi_unas/ssh_manager.py
+++ b/custom_components/unifi_unas/ssh_manager.py
@@ -10,7 +10,7 @@ from typing import Optional
 import aiofiles
 import asyncssh
 
-from .const import HA_SSH_KEY_PATHS
+from .const import ENV_MQTT_SECRET_KEYS, HA_SSH_KEY_PATHS, UNAS_ENV_FILE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,6 +32,13 @@ class SSHManager:
             mqtt_port: int = 1883,
             mqtt_tls: bool = False,
             mqtt_tls_insecure: bool = False,
+            credentials_file: Optional[str] = None,
+            min_pwm_floor: int = 0,
+            verify_host_key: bool = False,
+            known_hosts_path: Optional[str] = None,
+            pinned_host_key: Optional[str] = None,
+            enable_monitor: bool = True,
+            enable_fan_control: bool = True,
     ) -> None:
         self.host = host
         self.username = username
@@ -44,6 +51,16 @@ class SSHManager:
         self.mqtt_port = mqtt_port
         self.mqtt_tls = mqtt_tls
         self.mqtt_tls_insecure = mqtt_tls_insecure
+        self.credentials_file = credentials_file
+        self.min_pwm_floor = min_pwm_floor
+        self.verify_host_key = verify_host_key
+        self.known_hosts_path = known_hosts_path
+        self.pinned_host_key = pinned_host_key
+        self.enable_monitor = enable_monitor
+        self.enable_fan_control = enable_fan_control
+        # Captured on connect: the server's host key in "host keytype base64"
+        # known_hosts form, for trust-on-first-use pinning by the caller.
+        self.server_host_key: Optional[str] = None
         self._conn: Optional[asyncssh.SSHClientConnection] = None
         self._lock = asyncio.Lock()
 
@@ -77,6 +94,8 @@ class SSHManager:
                         _LOGGER.debug("Using SSH key from %s", key_path)
                         break
 
+            known_hosts = self._resolve_known_hosts()
+
             self._conn = await asyncio.wait_for(
                 asyncssh.connect(
                     self.host,
@@ -84,11 +103,50 @@ class SSHManager:
                     username=self.username,
                     password=self.password if self.password else None,
                     client_keys=client_keys,
-                    known_hosts=None,
+                    known_hosts=known_hosts,
                 ),
                 timeout=SSH_CONNECT_TIMEOUT,
             )
+            self._capture_server_host_key()
             _LOGGER.debug("SSH connection established")
+
+    def _resolve_known_hosts(self):
+        """Determine the asyncssh known_hosts argument.
+
+        - A user-supplied known_hosts file path takes precedence.
+        - Otherwise, if host-key verification is enabled and a key has already
+          been pinned, verify against just that key.
+        - Otherwise return None (verification disabled), preserving the prior
+          default behavior and allowing trust-on-first-use capture.
+        """
+        if self.known_hosts_path:
+            return self.known_hosts_path
+        if self.verify_host_key and self.pinned_host_key:
+            try:
+                return asyncssh.import_known_hosts(self.pinned_host_key)
+            except (ValueError, asyncssh.Error) as err:
+                _LOGGER.warning("Could not parse pinned host key, skipping verification: %s", err)
+                return None
+        return None
+
+    def _capture_server_host_key(self) -> None:
+        """Record the server's host key in known_hosts form for TOFU pinning."""
+        if self._conn is None:
+            return
+        try:
+            key = self._conn.get_server_host_key()
+        except Exception:  # noqa: BLE001 - best-effort capture
+            key = None
+        if key is None:
+            return
+        try:
+            parts = key.export_public_key().decode().strip().split()
+        except Exception:  # noqa: BLE001 - best-effort capture
+            return
+        if len(parts) < 2:
+            return
+        hostspec = self.host if self.port == 22 else f"[{self.host}]:{self.port}"
+        self.server_host_key = f"{hostspec} {parts[0]} {parts[1]}"
 
     async def disconnect(self) -> None:
         async with self._lock:
@@ -106,12 +164,15 @@ class SSHManager:
         return getattr(result, "stdout", "") or "", getattr(result, "stderr", "") or ""
 
     async def scripts_installed(self) -> bool:
-        stdout, _ = await self.execute_command(
-            "test -f /root/unas_monitor.py && test -f /root/fan_control.sh "
-            "&& python3 -c 'import paho.mqtt.client' 2>/dev/null "
-            "&& which mosquitto_sub >/dev/null 2>&1 "
-            "&& echo 'yes' || echo 'no'"
-        )
+        checks = []
+        if self.enable_monitor:
+            checks.append("test -f /root/unas_monitor.py")
+        if self.enable_fan_control:
+            checks.append("test -f /root/fan_control.sh")
+        checks.append("python3 -c 'import paho.mqtt.client' 2>/dev/null")
+        checks.append("which mosquitto_sub >/dev/null 2>&1")
+        cmd = " && ".join(checks) + " && echo 'yes' || echo 'no'"
+        stdout, _ = await self.execute_command(cmd)
         installed = stdout.strip() == "yes"
         _LOGGER.debug("Scripts installed: %s", installed)
         return installed
@@ -149,7 +210,9 @@ class SSHManager:
             _LOGGER.warning("Failed to kick native fan control: %s", stdout.strip())
         return success
 
-    def _replace_mqtt_credentials(self, script: str, mqtt_root: str) -> str:
+    def _replace_mqtt_credentials(
+        self, script: str, mqtt_root: str, skip_keys: tuple[str, ...] = ()
+    ) -> str:
         replacements = {
             "MQTT_HOST": self.mqtt_host,
             "MQTT_USER": self.mqtt_user,
@@ -161,6 +224,11 @@ class SSHManager:
         }
 
         for key, value in replacements.items():
+            # Keys delivered via the on-device env file are left as their
+            # "REPLACE_ME" placeholder so the secret is never inlined into the
+            # deployed script body; the environment supplies the real value.
+            if key in skip_keys:
+                continue
             # unas_monitor.py — escape for Python string literal
             escaped = value.replace("\\", "\\\\").replace('"', '\\"')
             script = script.replace(f'{key} = "REPLACE_ME"', f'{key} = "{escaped}"')
@@ -183,28 +251,82 @@ class SSHManager:
             async with aiofiles.open(SCRIPTS_DIR / "fan_control.service", "r") as f:
                 fan_control_service = await f.read()
 
+            # MQTT credential delivery.
+            #
+            # Default (no credentials_file): substitute the values directly into
+            # the script bodies, exactly as before.
+            #
+            # Opt-in (credentials_file set): deliver the MQTT settings through a
+            # root-only (chmod 600) EnvironmentFile on the NAS, referenced by the
+            # systemd units via `EnvironmentFile=`. The scripts read these from
+            # the environment, so the sensitive values (username/password) are
+            # never inlined into the deployed script bodies.
+            skip_keys: tuple[str, ...] = ()
+            if self.credentials_file:
+                await self._deploy_credentials_file()
+                skip_keys = ENV_MQTT_SECRET_KEYS
+            else:
+                # Remove any env file left over from a previous credentials_file
+                # deployment so it can't override the freshly inlined values.
+                await self.execute_command(f"rm -f {shlex.quote(UNAS_ENV_FILE)}")
+
             if self.mqtt_host and self.mqtt_user and self.mqtt_password:
-                monitor_script = self._replace_mqtt_credentials(monitor_script, mqtt_root)
-                fan_control_script = self._replace_mqtt_credentials(fan_control_script, mqtt_root)
+                monitor_script = self._replace_mqtt_credentials(
+                    monitor_script, mqtt_root, skip_keys=skip_keys
+                )
+                fan_control_script = self._replace_mqtt_credentials(
+                    fan_control_script, mqtt_root, skip_keys=skip_keys
+                )
 
             escaped_model = device_model.replace("\\", "\\\\").replace('"', '\\"')
             monitor_script = monitor_script.replace(
                 'DEVICE_MODEL = "UNAS_PRO"', f'DEVICE_MODEL = "{escaped_model}"'
             )
 
-            await self._upload_file("/root/unas_monitor.py", monitor_script, executable=True)
-            await self._upload_file("/etc/systemd/system/unas_monitor.service", monitor_service)
-            await self._upload_file("/root/fan_control.sh", fan_control_script, executable=True)
-            await self._upload_file("/etc/systemd/system/fan_control.service", fan_control_service)
+            fan_control_script = fan_control_script.replace(
+                'MIN_PWM_FLOOR="0"', f'MIN_PWM_FLOOR="{int(self.min_pwm_floor)}"'
+            )
 
             await self.execute_command("apt-get update && apt-get install -y mosquitto-clients python3-pip")
             await self.execute_command("pip3 install --ignore-installed paho-mqtt==2.1.0")
 
+            # Deploy / enable each on-device service independently so a
+            # monitoring-only install can leave the fans fully UNAS-managed
+            # (and vice-versa). A disabled service is stopped and removed.
+            if self.enable_monitor:
+                await self._upload_file("/root/unas_monitor.py", monitor_script, executable=True)
+                await self._upload_file("/etc/systemd/system/unas_monitor.service", monitor_service)
+            else:
+                await self.execute_command("systemctl stop unas_monitor 2>/dev/null || true")
+                await self.execute_command("systemctl disable unas_monitor 2>/dev/null || true")
+                await self.execute_command(
+                    "rm -f /root/unas_monitor.py /etc/systemd/system/unas_monitor.service"
+                )
+
+            if self.enable_fan_control:
+                await self._upload_file("/root/fan_control.sh", fan_control_script, executable=True)
+                await self._upload_file(
+                    "/etc/systemd/system/fan_control.service", fan_control_service
+                )
+            else:
+                await self.execute_command("systemctl stop fan_control 2>/dev/null || true")
+                await self.execute_command("systemctl disable fan_control 2>/dev/null || true")
+                await self.execute_command(
+                    "rm -f /root/fan_control.sh /etc/systemd/system/fan_control.service"
+                )
+                # Hand the fans back to firmware/automatic control.
+                await self.execute_command(
+                    'for e in /sys/class/hwmon/hwmon0/pwm*_enable; do '
+                    '[ -w "$e" ] && echo 2 > "$e"; done || true'
+                )
+
             await self.execute_command("systemctl daemon-reload")
-            await self.execute_command("systemctl enable unas_monitor")
-            await self.execute_command("systemctl restart unas_monitor")
-            await self.execute_command("systemctl enable fan_control")
-            await self.execute_command("systemctl restart fan_control")
+            if self.enable_monitor:
+                await self.execute_command("systemctl enable unas_monitor")
+                await self.execute_command("systemctl restart unas_monitor")
+            if self.enable_fan_control:
+                await self.execute_command("systemctl enable fan_control")
+                await self.execute_command("systemctl restart fan_control")
 
             _LOGGER.info("Scripts deployed and services started")
 
@@ -223,6 +345,27 @@ class SSHManager:
         if executable:
             safe_path = shlex.quote(remote_path)
             await self.execute_command(f"chmod +x {safe_path}")
+
+    async def _deploy_credentials_file(self) -> None:
+        """Upload the operator-supplied MQTT env file to the NAS (chmod 600).
+
+        The file at ``self.credentials_file`` lives on the Home Assistant host
+        and is expected to be a systemd EnvironmentFile defining at least
+        ``MQTT_USER`` and ``MQTT_PASS`` (and optionally any other ``MQTT_*``
+        settings). It is written to a root-only file on the NAS that the
+        systemd units load via ``EnvironmentFile=``.
+        """
+        cred_path = Path(self.credentials_file)
+        if not cred_path.is_file():
+            raise FileNotFoundError(
+                f"credentials_file not found on the Home Assistant host: {self.credentials_file}"
+            )
+        async with aiofiles.open(cred_path, "r") as f:
+            env_content = await f.read()
+
+        await self._upload_file(UNAS_ENV_FILE, env_content)
+        await self.execute_command(f"chmod 600 {shlex.quote(UNAS_ENV_FILE)}")
+        _LOGGER.info("Deployed MQTT credentials via EnvironmentFile %s", UNAS_ENV_FILE)
 
     async def execute_backup_api(self, method: str, endpoint: str) -> dict:
         cmd = f'''curl -s -X {method} "http://localhost:16080{endpoint}" \

--- a/custom_components/unifi_unas/strings.json
+++ b/custom_components/unifi_unas/strings.json
@@ -14,11 +14,23 @@
           "mqtt_tls": "Use TLS",
           "device_model": "Device Model",
           "device_name": "Device Name",
+          "credentials_file": "MQTT credentials file (optional)",
+          "verify_host_key": "Verify SSH host key",
+          "known_hosts": "SSH known_hosts file (optional)",
+          "enable_monitor": "Enable monitoring service",
+          "enable_fan_control": "Enable fan-control service",
+          "min_pwm_floor": "Minimum fan PWM floor (0-255, 0 = disabled)",
           "scan_interval": "Polling Interval (seconds, 5-60)"
         },
         "data_description": {
           "mqtt_tls": "Only enable if your MQTT broker is configured for TLS (port 8883). Leave off for standard setups.",
-          "device_name": "Optional custom name (e.g. UNAS Pro Hallway) - will be used for entity ID-s, e.g.: sensor.unas_pro_hallway_cpu_temperature"
+          "device_name": "Optional custom name (e.g. UNAS Pro Hallway) - will be used for entity ID-s, e.g.: sensor.unas_pro_hallway_cpu_temperature",
+          "credentials_file": "Optional path on the Home Assistant host to a root-readable env file defining MQTT_USER and MQTT_PASS (and optionally other MQTT_* settings). When set, the MQTT credentials are delivered to the NAS via a root-only systemd EnvironmentFile instead of being written into the on-device scripts. Leave blank for the standard setup.",
+          "verify_host_key": "Verify the NAS SSH host key. On the first connection the key is recorded (trust-on-first-use) and checked on every connection after that. Leave off to keep the current permissive behavior.",
+          "known_hosts": "Optional path on the Home Assistant host to a known_hosts file to verify the NAS host key against. Takes precedence over trust-on-first-use pinning when set.",
+          "enable_monitor": "Deploy and run the monitoring service that publishes sensor data. On by default.",
+          "enable_fan_control": "Deploy and run the fan-control service. Turn off for a monitoring-only install that leaves the fans fully UNAS-managed; the fan-control script is not deployed to the NAS.",
+          "min_pwm_floor": "Optional safety floor enforced in every actively-controlled fan mode, so a misconfigured curve or set speed can't drive the fans below this PWM value. 0 disables the floor (default)."
         }
       },
       "mqtt_tls": {
@@ -45,12 +57,24 @@
           "mqtt_tls": "Use TLS",
           "device_model": "Device Model",
           "device_name": "Device Name",
+          "credentials_file": "MQTT credentials file (optional)",
+          "verify_host_key": "Verify SSH host key",
+          "known_hosts": "SSH known_hosts file (optional)",
+          "enable_monitor": "Enable monitoring service",
+          "enable_fan_control": "Enable fan-control service",
+          "min_pwm_floor": "Minimum fan PWM floor (0-255, 0 = disabled)",
           "scan_interval": "Polling Interval (seconds, 5-60)"
         },
         "data_description": {
           "mqtt_tls": "Only enable if your MQTT broker is configured for TLS (port 8883). Leave off for standard setups.",
           "device_model": "WARNING: Changing the device model requires deleting and re-adding the integration to update drive entities.",
-          "device_name": "Changes device display names only. Entity IDs are set at initial setup and cannot be changed here."
+          "device_name": "Changes device display names only. Entity IDs are set at initial setup and cannot be changed here.",
+          "credentials_file": "Optional path on the Home Assistant host to a root-readable env file defining MQTT_USER and MQTT_PASS (and optionally other MQTT_* settings). When set, the MQTT credentials are delivered to the NAS via a root-only systemd EnvironmentFile instead of being written into the on-device scripts. Leave blank for the standard setup.",
+          "verify_host_key": "Verify the NAS SSH host key. On the first connection the key is recorded (trust-on-first-use) and checked on every connection after that. Leave off to keep the current permissive behavior.",
+          "known_hosts": "Optional path on the Home Assistant host to a known_hosts file to verify the NAS host key against. Takes precedence over trust-on-first-use pinning when set.",
+          "enable_monitor": "Deploy and run the monitoring service that publishes sensor data. On by default.",
+          "enable_fan_control": "Deploy and run the fan-control service. Turn off for a monitoring-only install that leaves the fans fully UNAS-managed; the fan-control script is not deployed to the NAS.",
+          "min_pwm_floor": "Optional safety floor enforced in every actively-controlled fan mode, so a misconfigured curve or set speed can't drive the fans below this PWM value. 0 disables the floor (default)."
         }
       },
       "reconfigure_mqtt_tls": {

--- a/custom_components/unifi_unas/translations/en.json
+++ b/custom_components/unifi_unas/translations/en.json
@@ -14,11 +14,23 @@
           "mqtt_tls": "Use TLS",
           "device_model": "Device Model",
           "device_name": "Device Name",
+          "credentials_file": "MQTT credentials file (optional)",
+          "verify_host_key": "Verify SSH host key",
+          "known_hosts": "SSH known_hosts file (optional)",
+          "enable_monitor": "Enable monitoring service",
+          "enable_fan_control": "Enable fan-control service",
+          "min_pwm_floor": "Minimum fan PWM floor (0-255, 0 = disabled)",
           "scan_interval": "Polling Interval (seconds, 5-60)"
         },
         "data_description": {
           "mqtt_tls": "Only enable if your MQTT broker is configured for TLS (port 8883). Leave off for standard setups.",
-          "device_name": "Optional custom name (e.g. UNAS Pro Hallway) - will be used for entity ID-s, e.g.: sensor.unas_pro_hallway_cpu_temperature"
+          "device_name": "Optional custom name (e.g. UNAS Pro Hallway) - will be used for entity ID-s, e.g.: sensor.unas_pro_hallway_cpu_temperature",
+          "credentials_file": "Optional path on the Home Assistant host to a root-readable env file defining MQTT_USER and MQTT_PASS (and optionally other MQTT_* settings). When set, the MQTT credentials are delivered to the NAS via a root-only systemd EnvironmentFile instead of being written into the on-device scripts. Leave blank for the standard setup.",
+          "verify_host_key": "Verify the NAS SSH host key. On the first connection the key is recorded (trust-on-first-use) and checked on every connection after that. Leave off to keep the current permissive behavior.",
+          "known_hosts": "Optional path on the Home Assistant host to a known_hosts file to verify the NAS host key against. Takes precedence over trust-on-first-use pinning when set.",
+          "enable_monitor": "Deploy and run the monitoring service that publishes sensor data. On by default.",
+          "enable_fan_control": "Deploy and run the fan-control service. Turn off for a monitoring-only install that leaves the fans fully UNAS-managed; the fan-control script is not deployed to the NAS.",
+          "min_pwm_floor": "Optional safety floor enforced in every actively-controlled fan mode, so a misconfigured curve or set speed can't drive the fans below this PWM value. 0 disables the floor (default)."
         }
       },
       "mqtt_tls": {
@@ -45,12 +57,24 @@
           "mqtt_tls": "Use TLS",
           "device_model": "Device Model",
           "device_name": "Device Name",
+          "credentials_file": "MQTT credentials file (optional)",
+          "verify_host_key": "Verify SSH host key",
+          "known_hosts": "SSH known_hosts file (optional)",
+          "enable_monitor": "Enable monitoring service",
+          "enable_fan_control": "Enable fan-control service",
+          "min_pwm_floor": "Minimum fan PWM floor (0-255, 0 = disabled)",
           "scan_interval": "Polling Interval (seconds, 5-60)"
         },
         "data_description": {
           "mqtt_tls": "Only enable if your MQTT broker is configured for TLS (port 8883). Leave off for standard setups.",
           "device_model": "WARNING: Changing the device model requires deleting and re-adding the integration to update drive entities.",
-          "device_name": "Changes device display names only. Entity IDs are set at initial setup and cannot be changed here."
+          "device_name": "Changes device display names only. Entity IDs are set at initial setup and cannot be changed here.",
+          "credentials_file": "Optional path on the Home Assistant host to a root-readable env file defining MQTT_USER and MQTT_PASS (and optionally other MQTT_* settings). When set, the MQTT credentials are delivered to the NAS via a root-only systemd EnvironmentFile instead of being written into the on-device scripts. Leave blank for the standard setup.",
+          "verify_host_key": "Verify the NAS SSH host key. On the first connection the key is recorded (trust-on-first-use) and checked on every connection after that. Leave off to keep the current permissive behavior.",
+          "known_hosts": "Optional path on the Home Assistant host to a known_hosts file to verify the NAS host key against. Takes precedence over trust-on-first-use pinning when set.",
+          "enable_monitor": "Deploy and run the monitoring service that publishes sensor data. On by default.",
+          "enable_fan_control": "Deploy and run the fan-control service. Turn off for a monitoring-only install that leaves the fans fully UNAS-managed; the fan-control script is not deployed to the NAS.",
+          "min_pwm_floor": "Optional safety floor enforced in every actively-controlled fan mode, so a misconfigured curve or set speed can't drive the fans below this PWM value. 0 disables the floor (default)."
         }
       },
       "reconfigure_mqtt_tls": {


### PR DESCRIPTION
*The following contribution was assisted using Copilot.*

This consolidates the four opt-in improvements I proposed in #33 into a single PR. Each is **opt-in with defaults that preserve current behavior**, and I've validated them end-to-end on a real UNAS Pro.

## Summary

**1. Externalize MQTT credentials (secrets management)**
An optional `credentials_file` delivers the MQTT settings via a root-only (`chmod 600`) systemd `EnvironmentFile`, so the scripts read them from the environment instead of the password being inlined into the on-device scripts. Default path unchanged.

**2. Fan control — restore automatic PWM on stop/crash (safety)**
`ExecStopPost` (and a shell `trap`) restore every `pwmN_enable` to automatic on any stop/crash; `Type=notify` + `WatchdogSec` restart a hung daemon rather than leaving a stale PWM; and an optional minimum-PWM floor guards against a misconfigured curve/speed. Items 1-3 there are pure safety and don't change steady-state cooling; the floor is opt-in.

**3. Optional SSH host-key verification (security)**
`ssh_manager.py` currently connects with `known_hosts=None`. This adds an optional trust-on-first-use pin (or a `known_hosts` path), defaulting to today's permissive behavior.

**4. Headless collector + independent service toggles (diagnostics)**
`unas_monitor.py --once --json` runs a single collection cycle and prints the full metric set as JSON without MQTT, plus options to deploy the monitor and fan-control services independently (e.g. a monitoring-only install). Purely additive.

## Notes
- **Backward compatible:** every new option defaults to current behavior; the UI gains a few optional fields on the setup/reconfigure steps.
- **Style:** I followed the repo's conventions and the changes introduce no new `ruff` findings versus the current tree; `strings.json`/`translations/en.json` are kept in sync for hassfest.
- I've kept this as one PR since the changes share several files (`config_flow.py`, `const.py`, `ssh_manager.py`), but I'm happy to split it, reorder, or drop anything to match your preferences.

Implements #33.
