### PR TITLE
Optional SSH host-key verification (trust-on-first-use, fail-closed, one-click re-pin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,14 @@ Instead of using a password, you can configure SSH key authentication for more s
 
 The integration will automatically detect and use the SSH key.
 
+### SSH Host Key Verification (Optional)
+
+By default the SSH connection to the NAS does not verify the host key. To have the integration verify it, enable **Verify SSH host key** during setup (or reconfigure). On the first successful connection the NAS host key is recorded (trust-on-first-use) and stored with the config entry; every connection afterwards is checked against it, so a man-in-the-middle presenting a different key is rejected.
+
+Alternatively, point **SSH known_hosts file** at a `known_hosts` file on the Home Assistant host; when set it is used to verify the host key and takes precedence over trust-on-first-use.
+
+If the NAS host key legitimately changes (for example after a firmware reinstall), the integration raises a repair notification offering to **re-pin** the new key in one step — no need to remove and re-add the integration. If verification is on and the stored key ever can't be read, the integration fails closed (it won't connect without verifying) and surfaces the same repair. Both options are off/blank by default, preserving current behavior.
+
 ### Secure MQTT (TLS) (Optional)
 
 If your MQTT broker is configured for TLS (e.g., port 8883), enable the **Use TLS** toggle during setup. After submitting the main form, you'll be prompted for:

--- a/custom_components/unifi_unas/__init__.py
+++ b/custom_components/unifi_unas/__init__.py
@@ -5,12 +5,13 @@ import logging
 import time
 from datetime import timedelta
 
+import asyncssh
 from packaging.version import Version, InvalidVersion
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryError, ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.components import mqtt
 from homeassistant.helpers import issue_registry as ir
@@ -27,6 +28,9 @@ from .const import (
     CONF_MQTT_PORT,
     CONF_MQTT_TLS,
     CONF_MQTT_TLS_INSECURE,
+    CONF_VERIFY_HOST_KEY,
+    CONF_KNOWN_HOSTS,
+    CONF_HOST_KEY,
     CONF_SCAN_INTERVAL,
     CONF_DEVICE_MODEL,
     DEFAULT_SCAN_INTERVAL,
@@ -35,7 +39,7 @@ from .const import (
     get_mqtt_root,
     get_mqtt_topics,
 )
-from .ssh_manager import SSHManager
+from .ssh_manager import SSHManager, HostKeyPinError
 from .mqtt_client import UNASMQTTClient
 
 _LOGGER = logging.getLogger(__name__)
@@ -166,6 +170,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         mqtt_port=entry.data.get(CONF_MQTT_PORT, DEFAULT_MQTT_PORT),
         mqtt_tls=entry.data.get(CONF_MQTT_TLS, False),
         mqtt_tls_insecure=entry.data.get(CONF_MQTT_TLS_INSECURE, False),
+        verify_host_key=entry.data.get(CONF_VERIFY_HOST_KEY, False),
+        known_hosts_path=entry.data.get(CONF_KNOWN_HOSTS),
+        pinned_host_key=entry.data.get(CONF_HOST_KEY),
     )
 
     integration = await async_get_integration(hass, DOMAIN)
@@ -181,6 +188,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         ssh_connected = True
         _LOGGER.info("SSH connection established to %s", entry.data[CONF_HOST])
 
+        # Trust-on-first-use: when verification is enabled and nothing is pinned
+        # yet, record the key seen on this first connection so later connections
+        # are verified against it.
+        if (
+            entry.data.get(CONF_VERIFY_HOST_KEY)
+            and not entry.data.get(CONF_HOST_KEY)
+            and manager.server_host_key
+        ):
+            new_data = dict(entry.data)
+            new_data[CONF_HOST_KEY] = manager.server_host_key
+            hass.config_entries.async_update_entry(entry, data=new_data)
+            manager.pinned_host_key = manager.server_host_key
+            _LOGGER.info("Pinned SSH host key for %s", entry.data[CONF_HOST])
+
+        # We connected/verified, so clear any outstanding host-key repair.
+        ir.async_delete_issue(hass, DOMAIN, f"host_key_changed_{entry.entry_id}")
+
         scripts_installed = await manager.scripts_installed()
         if last_deploy_version != current_version or not scripts_installed or is_dev_version:
             mqtt_root = get_mqtt_topics(entry.entry_id)["root"]
@@ -188,6 +212,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             new_data = dict(entry.data)
             new_data[LAST_DEPLOY_VERSION_KEY] = current_version
             hass.config_entries.async_update_entry(entry, data=new_data)
+
+    except (HostKeyPinError, asyncssh.HostKeyNotVerifiable) as err:
+        # The presented key doesn't match the pin (or the pin is unreadable).
+        # Fail closed and raise a repair the user can act on to re-pin.
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            f"host_key_changed_{entry.entry_id}",
+            is_fixable=True,
+            severity=ir.IssueSeverity.ERROR,
+            translation_key="host_key_changed",
+            translation_placeholders={"host": entry.data[CONF_HOST]},
+            data={"entry_id": entry.entry_id},
+        )
+        raise ConfigEntryError(
+            f"SSH host-key verification failed for {entry.data[CONF_HOST]}: {err}"
+        ) from err
 
     except Exception as err:
         if not is_existing_installation:

--- a/custom_components/unifi_unas/__init__.py
+++ b/custom_components/unifi_unas/__init__.py
@@ -29,7 +29,6 @@ from .const import (
     CONF_MQTT_TLS,
     CONF_MQTT_TLS_INSECURE,
     CONF_VERIFY_HOST_KEY,
-    CONF_KNOWN_HOSTS,
     CONF_HOST_KEY,
     CONF_SCAN_INTERVAL,
     CONF_DEVICE_MODEL,
@@ -171,7 +170,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         mqtt_tls=entry.data.get(CONF_MQTT_TLS, False),
         mqtt_tls_insecure=entry.data.get(CONF_MQTT_TLS_INSECURE, False),
         verify_host_key=entry.data.get(CONF_VERIFY_HOST_KEY, False),
-        known_hosts_path=entry.data.get(CONF_KNOWN_HOSTS),
         pinned_host_key=entry.data.get(CONF_HOST_KEY),
     )
 
@@ -215,7 +213,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     except (HostKeyPinError, asyncssh.HostKeyNotVerifiable) as err:
         # The presented key doesn't match the pin (or the pin is unreadable).
-        # Fail closed and raise a repair the user can act on to re-pin.
+        # Raise a repair the user can act on to re-pin, then degrade the same
+        # way any other SSH failure does: SSH is only used for script
+        # deploys/service status/backups, while all sensor data arrives over
+        # MQTT. On an existing install we keep those MQTT sensors running and
+        # only block a first-time setup.
         ir.async_create_issue(
             hass,
             DOMAIN,
@@ -226,9 +228,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             translation_placeholders={"host": entry.data[CONF_HOST]},
             data={"entry_id": entry.entry_id},
         )
-        raise ConfigEntryError(
-            f"SSH host-key verification failed for {entry.data[CONF_HOST]}: {err}"
-        ) from err
+        if not is_existing_installation:
+            raise ConfigEntryError(
+                f"SSH host-key verification failed for {entry.data[CONF_HOST]}: {err}"
+            ) from err
+        _LOGGER.warning(
+            "SSH host-key verification failed for %s; continuing with MQTT data "
+            "only until the key is re-pinned via the repair: %s",
+            entry.data[CONF_HOST],
+            err,
+        )
 
     except Exception as err:
         if not is_existing_installation:

--- a/custom_components/unifi_unas/config_flow.py
+++ b/custom_components/unifi_unas/config_flow.py
@@ -37,6 +37,8 @@ from .const import (
     CONF_MQTT_PORT,
     CONF_MQTT_TLS,
     CONF_MQTT_TLS_INSECURE,
+    CONF_VERIFY_HOST_KEY,
+    CONF_KNOWN_HOSTS,
     CONF_SCAN_INTERVAL,
     CONF_DEVICE_MODEL,
     CONF_DEVICE_NAME,
@@ -63,6 +65,8 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
             )
         ),
         vol.Optional(CONF_DEVICE_NAME, default="UNAS"): str,
+        vol.Optional(CONF_VERIFY_HOST_KEY, default=False): BooleanSelector(),
+        vol.Optional(CONF_KNOWN_HOSTS): str,
         vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): NumberSelector(
             NumberSelectorConfig(
                 min=MIN_SCAN_INTERVAL, max=MAX_SCAN_INTERVAL, mode=NumberSelectorMode.BOX
@@ -91,7 +95,8 @@ class UNASProConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if new_model != old_model:
                 errors["base"] = "model_changed"
             elif error_key := await self._test_ssh(user_input[CONF_HOST], user_input[CONF_USERNAME],
-                                                   user_input.get(CONF_PASSWORD)):
+                                                   user_input.get(CONF_PASSWORD),
+                                                   user_input.get(CONF_KNOWN_HOSTS)):
                 errors["base"] = error_key
             elif user_input.get(CONF_MQTT_TLS):
                 self._pending_input = user_input
@@ -132,6 +137,14 @@ class UNASProConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Optional(
                     CONF_DEVICE_NAME,
                     default=entry.data.get(CONF_DEVICE_NAME) or "UNAS",
+                ): str,
+                vol.Optional(
+                    CONF_VERIFY_HOST_KEY,
+                    default=entry.data.get(CONF_VERIFY_HOST_KEY, False),
+                ): BooleanSelector(),
+                vol.Optional(
+                    CONF_KNOWN_HOSTS,
+                    default=entry.data.get(CONF_KNOWN_HOSTS) or "",
                 ): str,
                 vol.Optional(CONF_SCAN_INTERVAL,
                              default=entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)): NumberSelector(
@@ -201,7 +214,8 @@ class UNASProConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             if error_key := await self._test_ssh(user_input[CONF_HOST], user_input[CONF_USERNAME],
-                                                 user_input.get(CONF_PASSWORD)):
+                                                 user_input.get(CONF_PASSWORD),
+                                                 user_input.get(CONF_KNOWN_HOSTS)):
                 errors["base"] = error_key
             elif user_input.get(CONF_MQTT_TLS):
                 self._pending_input = user_input
@@ -258,7 +272,10 @@ class UNASProConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         })
         return self.async_show_form(step_id="mqtt_tls", data_schema=schema, errors=errors)
 
-    async def _test_ssh(self, host: str, username: str, password: str | None) -> str | None:
+    async def _test_ssh(
+        self, host: str, username: str, password: str | None,
+        known_hosts_path: str | None = None,
+    ) -> str | None:
         try:
             client_keys = None
             if not password:
@@ -274,7 +291,7 @@ class UNASProConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     username=username,
                     password=password if password else None,
                     client_keys=client_keys,
-                    known_hosts=None,
+                    known_hosts=known_hosts_path or None,
                 ),
                 timeout=10.0,
             )

--- a/custom_components/unifi_unas/config_flow.py
+++ b/custom_components/unifi_unas/config_flow.py
@@ -38,7 +38,6 @@ from .const import (
     CONF_MQTT_TLS,
     CONF_MQTT_TLS_INSECURE,
     CONF_VERIFY_HOST_KEY,
-    CONF_KNOWN_HOSTS,
     CONF_SCAN_INTERVAL,
     CONF_DEVICE_MODEL,
     CONF_DEVICE_NAME,
@@ -66,7 +65,6 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
         ),
         vol.Optional(CONF_DEVICE_NAME, default="UNAS"): str,
         vol.Optional(CONF_VERIFY_HOST_KEY, default=False): BooleanSelector(),
-        vol.Optional(CONF_KNOWN_HOSTS): str,
         vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): NumberSelector(
             NumberSelectorConfig(
                 min=MIN_SCAN_INTERVAL, max=MAX_SCAN_INTERVAL, mode=NumberSelectorMode.BOX
@@ -95,8 +93,7 @@ class UNASProConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if new_model != old_model:
                 errors["base"] = "model_changed"
             elif error_key := await self._test_ssh(user_input[CONF_HOST], user_input[CONF_USERNAME],
-                                                   user_input.get(CONF_PASSWORD),
-                                                   user_input.get(CONF_KNOWN_HOSTS)):
+                                                   user_input.get(CONF_PASSWORD)):
                 errors["base"] = error_key
             elif user_input.get(CONF_MQTT_TLS):
                 self._pending_input = user_input
@@ -142,10 +139,6 @@ class UNASProConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     CONF_VERIFY_HOST_KEY,
                     default=entry.data.get(CONF_VERIFY_HOST_KEY, False),
                 ): BooleanSelector(),
-                vol.Optional(
-                    CONF_KNOWN_HOSTS,
-                    default=entry.data.get(CONF_KNOWN_HOSTS) or "",
-                ): str,
                 vol.Optional(CONF_SCAN_INTERVAL,
                              default=entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)): NumberSelector(
                     NumberSelectorConfig(min=MIN_SCAN_INTERVAL, max=MAX_SCAN_INTERVAL, mode=NumberSelectorMode.BOX)
@@ -214,8 +207,7 @@ class UNASProConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             if error_key := await self._test_ssh(user_input[CONF_HOST], user_input[CONF_USERNAME],
-                                                 user_input.get(CONF_PASSWORD),
-                                                 user_input.get(CONF_KNOWN_HOSTS)):
+                                                 user_input.get(CONF_PASSWORD)):
                 errors["base"] = error_key
             elif user_input.get(CONF_MQTT_TLS):
                 self._pending_input = user_input
@@ -272,10 +264,7 @@ class UNASProConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         })
         return self.async_show_form(step_id="mqtt_tls", data_schema=schema, errors=errors)
 
-    async def _test_ssh(
-        self, host: str, username: str, password: str | None,
-        known_hosts_path: str | None = None,
-    ) -> str | None:
+    async def _test_ssh(self, host: str, username: str, password: str | None) -> str | None:
         try:
             client_keys = None
             if not password:
@@ -291,7 +280,7 @@ class UNASProConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     username=username,
                     password=password if password else None,
                     client_keys=client_keys,
-                    known_hosts=known_hosts_path or None,
+                    known_hosts=None,
                 ),
                 timeout=10.0,
             )

--- a/custom_components/unifi_unas/const.py
+++ b/custom_components/unifi_unas/const.py
@@ -20,6 +20,9 @@ CONF_MQTT_PASSWORD = "mqtt_password"
 CONF_MQTT_PORT = "mqtt_port"
 CONF_MQTT_TLS = "mqtt_tls"
 CONF_MQTT_TLS_INSECURE = "mqtt_tls_insecure"
+CONF_VERIFY_HOST_KEY = "verify_host_key"
+CONF_KNOWN_HOSTS = "known_hosts"
+CONF_HOST_KEY = "host_key"
 CONF_SCAN_INTERVAL = "scan_interval"
 
 DEFAULT_MQTT_PORT = 1883

--- a/custom_components/unifi_unas/const.py
+++ b/custom_components/unifi_unas/const.py
@@ -21,7 +21,6 @@ CONF_MQTT_PORT = "mqtt_port"
 CONF_MQTT_TLS = "mqtt_tls"
 CONF_MQTT_TLS_INSECURE = "mqtt_tls_insecure"
 CONF_VERIFY_HOST_KEY = "verify_host_key"
-CONF_KNOWN_HOSTS = "known_hosts"
 CONF_HOST_KEY = "host_key"
 CONF_SCAN_INTERVAL = "scan_interval"
 

--- a/custom_components/unifi_unas/repairs.py
+++ b/custom_components/unifi_unas/repairs.py
@@ -1,0 +1,61 @@
+"""Repair flows for the UniFi UNAS integration."""
+from __future__ import annotations
+
+import logging
+
+import voluptuous as vol
+from homeassistant import data_entry_flow
+from homeassistant.components.repairs import RepairsFlow
+from homeassistant.core import HomeAssistant
+
+from .const import CONF_HOST_KEY
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class HostKeyChangedRepairFlow(RepairsFlow):
+    """Offer to re-pin the NAS SSH host key after a legitimate key change."""
+
+    def __init__(self, entry_id: str) -> None:
+        self._entry_id = entry_id
+
+    async def async_step_init(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        return await self.async_step_confirm()
+
+    async def async_step_confirm(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        if user_input is not None:
+            entry = self.hass.config_entries.async_get_entry(self._entry_id)
+            if entry is not None:
+                # Clear the stored pin; the next connection re-pins via
+                # trust-on-first-use and reloading applies it immediately.
+                new_data = dict(entry.data)
+                new_data.pop(CONF_HOST_KEY, None)
+                self.hass.config_entries.async_update_entry(entry, data=new_data)
+                await self.hass.config_entries.async_reload(self._entry_id)
+            return self.async_create_entry(title="", data={})
+
+        return self.async_show_form(step_id="confirm", data_schema=vol.Schema({}))
+
+
+async def async_create_fix_flow(
+    hass: HomeAssistant,
+    issue_id: str,
+    data: dict[str, str] | None,
+) -> RepairsFlow:
+    """Create the fix flow for a repair issue."""
+    entry_id = (data or {}).get("entry_id", "")
+    if issue_id.startswith("host_key_changed") and entry_id:
+        return HostKeyChangedRepairFlow(entry_id)
+    # Unknown/non-fixable issue: a no-op confirm flow.
+    return _NoopRepairFlow()
+
+
+class _NoopRepairFlow(RepairsFlow):
+    async def async_step_init(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        return self.async_create_entry(title="", data={})

--- a/custom_components/unifi_unas/repairs.py
+++ b/custom_components/unifi_unas/repairs.py
@@ -8,7 +8,7 @@ from homeassistant import data_entry_flow
 from homeassistant.components.repairs import RepairsFlow
 from homeassistant.core import HomeAssistant
 
-from .const import CONF_HOST_KEY
+from .const import CONF_HOST, CONF_HOST_KEY
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -27,8 +27,8 @@ class HostKeyChangedRepairFlow(RepairsFlow):
     async def async_step_confirm(
         self, user_input: dict[str, str] | None = None
     ) -> data_entry_flow.FlowResult:
+        entry = self.hass.config_entries.async_get_entry(self._entry_id)
         if user_input is not None:
-            entry = self.hass.config_entries.async_get_entry(self._entry_id)
             if entry is not None:
                 # Clear the stored pin; the next connection re-pins via
                 # trust-on-first-use and reloading applies it immediately.
@@ -38,7 +38,12 @@ class HostKeyChangedRepairFlow(RepairsFlow):
                 await self.hass.config_entries.async_reload(self._entry_id)
             return self.async_create_entry(title="", data={})
 
-        return self.async_show_form(step_id="confirm", data_schema=vol.Schema({}))
+        host = entry.data.get(CONF_HOST, "") if entry is not None else ""
+        return self.async_show_form(
+            step_id="confirm",
+            data_schema=vol.Schema({}),
+            description_placeholders={"host": host},
+        )
 
 
 async def async_create_fix_flow(

--- a/custom_components/unifi_unas/ssh_manager.py
+++ b/custom_components/unifi_unas/ssh_manager.py
@@ -41,7 +41,6 @@ class SSHManager:
             mqtt_tls: bool = False,
             mqtt_tls_insecure: bool = False,
             verify_host_key: bool = False,
-            known_hosts_path: Optional[str] = None,
             pinned_host_key: Optional[str] = None,
     ) -> None:
         self.host = host
@@ -56,7 +55,6 @@ class SSHManager:
         self.mqtt_tls = mqtt_tls
         self.mqtt_tls_insecure = mqtt_tls_insecure
         self.verify_host_key = verify_host_key
-        self.known_hosts_path = known_hosts_path
         self.pinned_host_key = pinned_host_key
         # Populated on connect with the server's host key in known_hosts form
         # ("host keytype base64"), for trust-on-first-use pinning by the caller.
@@ -114,15 +112,12 @@ class SSHManager:
         """Choose the asyncssh known_hosts argument.
 
         Precedence:
-        1. A user-supplied known_hosts file path.
-        2. If verification is enabled and a key has been pinned, verify against
+        1. If verification is enabled and a key has been pinned, verify against
            just that key. If the stored pin can't be parsed, fail closed by
            raising HostKeyPinError rather than falling back to no verification.
-        3. Otherwise None -- verification disabled (default behavior), and the
+        2. Otherwise None -- verification disabled (default behavior), and the
            permissive first connection that trust-on-first-use captures from.
         """
-        if self.known_hosts_path:
-            return self.known_hosts_path
         if self.verify_host_key and self.pinned_host_key:
             try:
                 return asyncssh.import_known_hosts(self.pinned_host_key)

--- a/custom_components/unifi_unas/ssh_manager.py
+++ b/custom_components/unifi_unas/ssh_manager.py
@@ -18,6 +18,14 @@ SCRIPTS_DIR = Path(__file__).parent / "scripts"
 SSH_CONNECT_TIMEOUT = 30
 
 
+class HostKeyPinError(Exception):
+    """Raised when host-key verification is enabled but the stored pin is unusable.
+
+    Kept distinct from asyncssh's own errors so setup can fail closed (rather
+    than silently connecting without verification) and surface a repair.
+    """
+
+
 class SSHManager:
     def __init__(
             self,
@@ -32,6 +40,9 @@ class SSHManager:
             mqtt_port: int = 1883,
             mqtt_tls: bool = False,
             mqtt_tls_insecure: bool = False,
+            verify_host_key: bool = False,
+            known_hosts_path: Optional[str] = None,
+            pinned_host_key: Optional[str] = None,
     ) -> None:
         self.host = host
         self.username = username
@@ -44,6 +55,12 @@ class SSHManager:
         self.mqtt_port = mqtt_port
         self.mqtt_tls = mqtt_tls
         self.mqtt_tls_insecure = mqtt_tls_insecure
+        self.verify_host_key = verify_host_key
+        self.known_hosts_path = known_hosts_path
+        self.pinned_host_key = pinned_host_key
+        # Populated on connect with the server's host key in known_hosts form
+        # ("host keytype base64"), for trust-on-first-use pinning by the caller.
+        self.server_host_key: Optional[str] = None
         self._conn: Optional[asyncssh.SSHClientConnection] = None
         self._lock = asyncio.Lock()
 
@@ -77,6 +94,8 @@ class SSHManager:
                         _LOGGER.debug("Using SSH key from %s", key_path)
                         break
 
+            known_hosts = self._resolve_known_hosts()
+
             self._conn = await asyncio.wait_for(
                 asyncssh.connect(
                     self.host,
@@ -84,11 +103,48 @@ class SSHManager:
                     username=self.username,
                     password=self.password if self.password else None,
                     client_keys=client_keys,
-                    known_hosts=None,
+                    known_hosts=known_hosts,
                 ),
                 timeout=SSH_CONNECT_TIMEOUT,
             )
+            self._capture_server_host_key()
             _LOGGER.debug("SSH connection established")
+
+    def _resolve_known_hosts(self):
+        """Choose the asyncssh known_hosts argument.
+
+        Precedence:
+        1. A user-supplied known_hosts file path.
+        2. If verification is enabled and a key has been pinned, verify against
+           just that key. If the stored pin can't be parsed, fail closed by
+           raising HostKeyPinError rather than falling back to no verification.
+        3. Otherwise None -- verification disabled (default behavior), and the
+           permissive first connection that trust-on-first-use captures from.
+        """
+        if self.known_hosts_path:
+            return self.known_hosts_path
+        if self.verify_host_key and self.pinned_host_key:
+            try:
+                return asyncssh.import_known_hosts(self.pinned_host_key)
+            except (ValueError, asyncssh.Error) as err:
+                raise HostKeyPinError(
+                    f"Stored SSH host key for {self.host} is unreadable: {err}"
+                ) from err
+        return None
+
+    def _capture_server_host_key(self) -> None:
+        """Record the server's host key in known_hosts form for TOFU pinning."""
+        if self._conn is None:
+            return
+        try:
+            key = self._conn.get_server_host_key()
+            parts = key.export_public_key().decode().strip().split()
+        except Exception:  # noqa: BLE001 - best-effort capture
+            return
+        if len(parts) < 2:
+            return
+        hostspec = self.host if self.port == 22 else f"[{self.host}]:{self.port}"
+        self.server_host_key = f"{hostspec} {parts[0]} {parts[1]}"
 
     async def disconnect(self) -> None:
         async with self._lock:

--- a/custom_components/unifi_unas/strings.json
+++ b/custom_components/unifi_unas/strings.json
@@ -14,11 +14,15 @@
           "mqtt_tls": "Use TLS",
           "device_model": "Device Model",
           "device_name": "Device Name",
+          "verify_host_key": "Verify SSH host key",
+          "known_hosts": "SSH known_hosts file (optional)",
           "scan_interval": "Polling Interval (seconds, 5-60)"
         },
         "data_description": {
           "mqtt_tls": "Only enable if your MQTT broker is configured for TLS (port 8883). Leave off for standard setups.",
-          "device_name": "Optional custom name (e.g. UNAS Pro Hallway) - will be used for entity ID-s, e.g.: sensor.unas_pro_hallway_cpu_temperature"
+          "device_name": "Optional custom name (e.g. UNAS Pro Hallway) - will be used for entity ID-s, e.g.: sensor.unas_pro_hallway_cpu_temperature",
+          "verify_host_key": "Verify the NAS SSH host key. On the first connection the key is recorded (trust-on-first-use) and checked on every connection after that. Leave off to keep the current permissive behavior.",
+          "known_hosts": "Optional path on the Home Assistant host to a known_hosts file to verify the NAS host key against. Takes precedence over trust-on-first-use pinning when set."
         }
       },
       "mqtt_tls": {
@@ -45,12 +49,16 @@
           "mqtt_tls": "Use TLS",
           "device_model": "Device Model",
           "device_name": "Device Name",
+          "verify_host_key": "Verify SSH host key",
+          "known_hosts": "SSH known_hosts file (optional)",
           "scan_interval": "Polling Interval (seconds, 5-60)"
         },
         "data_description": {
           "mqtt_tls": "Only enable if your MQTT broker is configured for TLS (port 8883). Leave off for standard setups.",
           "device_model": "WARNING: Changing the device model requires deleting and re-adding the integration to update drive entities.",
-          "device_name": "Changes device display names only. Entity IDs are set at initial setup and cannot be changed here."
+          "device_name": "Changes device display names only. Entity IDs are set at initial setup and cannot be changed here.",
+          "verify_host_key": "Verify the NAS SSH host key. On the first connection the key is recorded (trust-on-first-use) and checked on every connection after that. Leave off to keep the current permissive behavior.",
+          "known_hosts": "Optional path on the Home Assistant host to a known_hosts file to verify the NAS host key against. Takes precedence over trust-on-first-use pinning when set."
         }
       },
       "reconfigure_mqtt_tls": {
@@ -105,6 +113,17 @@
     "ssh_unavailable": {
       "title": "UNAS SSH connection unavailable",
       "description": "Home Assistant has been unable to connect to your UniFi UNAS at `{host}` via SSH for over 10 minutes. Without SSH, the integration cannot check or redeploy monitoring scripts.\n\nThis can happen after a firmware upgrade if the SSH password was reset. Verify that you can SSH into the UNAS manually, then reload the integration.\n\nIf the password changed, update it via the integration's reconfigure option."
+    },
+    "host_key_changed": {
+      "title": "UniFi UNAS SSH host key changed",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-pin the UniFi UNAS SSH host key",
+            "description": "The SSH host key presented by the NAS at {host} no longer matches the pinned key. If you expected this (for example after a firmware reinstall), select **Submit** to trust the new key and re-pin it. If you did not expect it, cancel and investigate before continuing."
+          }
+        }
+      }
     }
   }
 }

--- a/custom_components/unifi_unas/strings.json
+++ b/custom_components/unifi_unas/strings.json
@@ -15,14 +15,12 @@
           "device_model": "Device Model",
           "device_name": "Device Name",
           "verify_host_key": "Verify SSH host key",
-          "known_hosts": "SSH known_hosts file (optional)",
           "scan_interval": "Polling Interval (seconds, 5-60)"
         },
         "data_description": {
           "mqtt_tls": "Only enable if your MQTT broker is configured for TLS (port 8883). Leave off for standard setups.",
           "device_name": "Optional custom name (e.g. UNAS Pro Hallway) - will be used for entity ID-s, e.g.: sensor.unas_pro_hallway_cpu_temperature",
-          "verify_host_key": "Verify the NAS SSH host key. On the first connection the key is recorded (trust-on-first-use) and checked on every connection after that. Leave off to keep the current permissive behavior.",
-          "known_hosts": "Optional path on the Home Assistant host to a known_hosts file to verify the NAS host key against. Takes precedence over trust-on-first-use pinning when set."
+          "verify_host_key": "Verify the NAS SSH host key. On the first connection the key is recorded (trust-on-first-use) and checked on every connection after that. Leave off to keep the current permissive behavior."
         }
       },
       "mqtt_tls": {
@@ -50,15 +48,13 @@
           "device_model": "Device Model",
           "device_name": "Device Name",
           "verify_host_key": "Verify SSH host key",
-          "known_hosts": "SSH known_hosts file (optional)",
           "scan_interval": "Polling Interval (seconds, 5-60)"
         },
         "data_description": {
           "mqtt_tls": "Only enable if your MQTT broker is configured for TLS (port 8883). Leave off for standard setups.",
           "device_model": "WARNING: Changing the device model requires deleting and re-adding the integration to update drive entities.",
           "device_name": "Changes device display names only. Entity IDs are set at initial setup and cannot be changed here.",
-          "verify_host_key": "Verify the NAS SSH host key. On the first connection the key is recorded (trust-on-first-use) and checked on every connection after that. Leave off to keep the current permissive behavior.",
-          "known_hosts": "Optional path on the Home Assistant host to a known_hosts file to verify the NAS host key against. Takes precedence over trust-on-first-use pinning when set."
+          "verify_host_key": "Verify the NAS SSH host key. On the first connection the key is recorded (trust-on-first-use) and checked on every connection after that. Leave off to keep the current permissive behavior."
         }
       },
       "reconfigure_mqtt_tls": {

--- a/custom_components/unifi_unas/translations/en.json
+++ b/custom_components/unifi_unas/translations/en.json
@@ -14,11 +14,15 @@
           "mqtt_tls": "Use TLS",
           "device_model": "Device Model",
           "device_name": "Device Name",
+          "verify_host_key": "Verify SSH host key",
+          "known_hosts": "SSH known_hosts file (optional)",
           "scan_interval": "Polling Interval (seconds, 5-60)"
         },
         "data_description": {
           "mqtt_tls": "Only enable if your MQTT broker is configured for TLS (port 8883). Leave off for standard setups.",
-          "device_name": "Optional custom name (e.g. UNAS Pro Hallway) - will be used for entity ID-s, e.g.: sensor.unas_pro_hallway_cpu_temperature"
+          "device_name": "Optional custom name (e.g. UNAS Pro Hallway) - will be used for entity ID-s, e.g.: sensor.unas_pro_hallway_cpu_temperature",
+          "verify_host_key": "Verify the NAS SSH host key. On the first connection the key is recorded (trust-on-first-use) and checked on every connection after that. Leave off to keep the current permissive behavior.",
+          "known_hosts": "Optional path on the Home Assistant host to a known_hosts file to verify the NAS host key against. Takes precedence over trust-on-first-use pinning when set."
         }
       },
       "mqtt_tls": {
@@ -45,12 +49,16 @@
           "mqtt_tls": "Use TLS",
           "device_model": "Device Model",
           "device_name": "Device Name",
+          "verify_host_key": "Verify SSH host key",
+          "known_hosts": "SSH known_hosts file (optional)",
           "scan_interval": "Polling Interval (seconds, 5-60)"
         },
         "data_description": {
           "mqtt_tls": "Only enable if your MQTT broker is configured for TLS (port 8883). Leave off for standard setups.",
           "device_model": "WARNING: Changing the device model requires deleting and re-adding the integration to update drive entities.",
-          "device_name": "Changes device display names only. Entity IDs are set at initial setup and cannot be changed here."
+          "device_name": "Changes device display names only. Entity IDs are set at initial setup and cannot be changed here.",
+          "verify_host_key": "Verify the NAS SSH host key. On the first connection the key is recorded (trust-on-first-use) and checked on every connection after that. Leave off to keep the current permissive behavior.",
+          "known_hosts": "Optional path on the Home Assistant host to a known_hosts file to verify the NAS host key against. Takes precedence over trust-on-first-use pinning when set."
         }
       },
       "reconfigure_mqtt_tls": {
@@ -105,6 +113,17 @@
     "ssh_unavailable": {
       "title": "UNAS SSH connection unavailable",
       "description": "Home Assistant has been unable to connect to your UniFi UNAS at `{host}` via SSH for over 10 minutes. Without SSH, the integration cannot check or redeploy monitoring scripts.\n\nThis can happen after a firmware upgrade if the SSH password was reset. Verify that you can SSH into the UNAS manually, then reload the integration.\n\nIf the password changed, update it via the integration's reconfigure option."
+    },
+    "host_key_changed": {
+      "title": "UniFi UNAS SSH host key changed",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-pin the UniFi UNAS SSH host key",
+            "description": "The SSH host key presented by the NAS at {host} no longer matches the pinned key. If you expected this (for example after a firmware reinstall), select **Submit** to trust the new key and re-pin it. If you did not expect it, cancel and investigate before continuing."
+          }
+        }
+      }
     }
   }
 }

--- a/custom_components/unifi_unas/translations/en.json
+++ b/custom_components/unifi_unas/translations/en.json
@@ -15,14 +15,12 @@
           "device_model": "Device Model",
           "device_name": "Device Name",
           "verify_host_key": "Verify SSH host key",
-          "known_hosts": "SSH known_hosts file (optional)",
           "scan_interval": "Polling Interval (seconds, 5-60)"
         },
         "data_description": {
           "mqtt_tls": "Only enable if your MQTT broker is configured for TLS (port 8883). Leave off for standard setups.",
           "device_name": "Optional custom name (e.g. UNAS Pro Hallway) - will be used for entity ID-s, e.g.: sensor.unas_pro_hallway_cpu_temperature",
-          "verify_host_key": "Verify the NAS SSH host key. On the first connection the key is recorded (trust-on-first-use) and checked on every connection after that. Leave off to keep the current permissive behavior.",
-          "known_hosts": "Optional path on the Home Assistant host to a known_hosts file to verify the NAS host key against. Takes precedence over trust-on-first-use pinning when set."
+          "verify_host_key": "Verify the NAS SSH host key. On the first connection the key is recorded (trust-on-first-use) and checked on every connection after that. Leave off to keep the current permissive behavior."
         }
       },
       "mqtt_tls": {
@@ -50,15 +48,13 @@
           "device_model": "Device Model",
           "device_name": "Device Name",
           "verify_host_key": "Verify SSH host key",
-          "known_hosts": "SSH known_hosts file (optional)",
           "scan_interval": "Polling Interval (seconds, 5-60)"
         },
         "data_description": {
           "mqtt_tls": "Only enable if your MQTT broker is configured for TLS (port 8883). Leave off for standard setups.",
           "device_model": "WARNING: Changing the device model requires deleting and re-adding the integration to update drive entities.",
           "device_name": "Changes device display names only. Entity IDs are set at initial setup and cannot be changed here.",
-          "verify_host_key": "Verify the NAS SSH host key. On the first connection the key is recorded (trust-on-first-use) and checked on every connection after that. Leave off to keep the current permissive behavior.",
-          "known_hosts": "Optional path on the Home Assistant host to a known_hosts file to verify the NAS host key against. Takes precedence over trust-on-first-use pinning when set."
+          "verify_host_key": "Verify the NAS SSH host key. On the first connection the key is recorded (trust-on-first-use) and checked on every connection after that. Leave off to keep the current permissive behavior."
         }
       },
       "reconfigure_mqtt_tls": {


### PR DESCRIPTION
*The following contribution was assisted using Copilot.*

This adds optional trust-on-first-use SSH host-key verification for the privileged SSH connection used to deploy and manage the on-device scripts.

## What this adds
- **Verify SSH host key** (`verify_host_key`): the key seen on the first connection is stored in the config entry and verified on later connections. A mismatch or unusable stored pin is rejected.
- Verification remains opt-in and defaults off, preserving current behavior.

## Failure behavior
- On an existing installation, a verification failure raises a re-pin repair and follows the existing degraded SSH path, so MQTT-backed sensors keep running while SSH deploy, status, and backup operations remain unavailable.
- During first-time setup, the same failure blocks setup rather than connecting without verification.

## Repair flow
The fixable repair shows the configured host and allows the user to trust and pin the replacement key without removing and re-adding the integration. The repair clears after a verified connection succeeds.

## Changes after review
1. Preserved degraded operation for existing installations instead of taking down the integration.
2. Filled the `{host}` placeholder in the repair dialog.
3. Removed the `known_hosts` path option and kept only the TOFU toggle.

## Validation
HACS validation and hassfest pass on the updated branch.