### PR TITLE
Monitor drives whose ata port has no bay mapping instead of dropping them

### DIFF
--- a/custom_components/unifi_unas/scripts/unas_monitor.py
+++ b/custom_components/unifi_unas/scripts/unas_monitor.py
@@ -144,6 +144,7 @@ class UNASMonitor:
         self._protect_api_warned = False
         self.bay_cache = {}
         self.known_drives = set()
+        self.warned_unmapped_ata = set()
         self.previous_drive_map = {}  # serial -> bay
         self.drive_removed_at = {}  # serial -> (timestamp, bay)
         self.grace_period = 60
@@ -537,8 +538,29 @@ class UNASMonitor:
         output = self.run_cmd(['udevadm', 'info', '-q', 'path', '-n', f'/dev/{device}'])
         bay = None
         for part in output.split('/'):
-            if part.startswith('ata') and (ata_num := part[3:]) in ATA_TO_BAY:
-                bay = ATA_TO_BAY[ata_num]
+            if part.startswith('ata') and part[3:].isdigit():
+                ata_num = part[3:]
+                if ATA_TO_BAY and ata_num in ATA_TO_BAY:
+                    bay = ATA_TO_BAY[ata_num]
+                else:
+                    # The per-model ATA_TO_BAY tables are community-sourced and
+                    # can be incomplete: a unit may populate an ata port that the
+                    # reference unit for this model did not. Rather than silently
+                    # dropping the drive -- which hides a real disk, including a
+                    # RAID member, from monitoring entirely -- fall back to
+                    # labeling the bay by its ata port. The "ata" prefix keeps it
+                    # from colliding with a mapped numeric bay. Logged once so the
+                    # correct mapping can be reported and added.
+                    bay = f"ata{ata_num}"
+                    if ata_num not in self.warned_unmapped_ata:
+                        self.warned_unmapped_ata.add(ata_num)
+                        logger.warning(
+                            "No %s bay mapping for ata%s (/dev/%s); reporting it "
+                            "as bay '%s' so the drive is still monitored. Please "
+                            "report this device model's ata->bay layout so the "
+                            "mapping can be completed.",
+                            DEVICE_MODEL, ata_num, device, bay,
+                        )
                 break
 
         self.bay_cache[device] = bay


### PR DESCRIPTION
*The following contribution was assisted using Copilot.*

### Summary

`get_bay_number()` looks up each drive's ata port in the per-model `ATA_TO_BAY` table and returns `None` when the port isn't found; `get_drives()` then skips any drive with no bay (`if not bay: continue`). Because those tables are community-sourced and per-model, a unit that populates an ata port the reference unit didn't have makes a **real drive disappear from monitoring entirely** — including a RAID member.

### How I hit this

On my 7-bay UNAS Pro, the `UNAS_PRO` table maps ata `1, 3, 4, 5, 6, 7, 8` and has no entry for `ata2`. My four disks enumerate on `ata1`–`ata4`, so the `ata2` disk — a healthy RAID10 member — produced **no entities at all**. Home Assistant showed SMART/temperature for only 3 of the 4 drives, so a failure on that disk would have gone unmonitored. The disk itself is fine (`smartctl` PASSED, 0 reallocated/pending sectors); it was purely a monitoring blind spot.

There's no reliable authoritative bay source on the hardware to fall back to (the `/api/v2/storage` `disks[]` `location` field is empty and there's no SES enclosure on the direct-attached SATA backplane), so the `ATA_TO_BAY` table remains the mechanism — it just needs to fail safe.

### Change

When a drive's ata port has no entry in the model table, label its bay by the ata port itself (e.g. `ata2`) and log a warning once, instead of dropping the drive. This keeps every physical drive monitored on any topology, and the warning surfaces the exact `ata -> ?` gap so the correct numeric mapping can be reported and added later (the same way the existing per-model mappings were sourced).

Details:
- The `ata` prefix on the fallback id keeps it from colliding with a mapped **numeric** bay (e.g. `UNAS_PRO` maps another port to bay `2`).
- Also guards `ATA_TO_BAY` being `None` for an unrecognized model, which previously would have raised in the `in` membership test; such models now surface all drives via the fallback rather than erroring.
- Existing mapped bays are unchanged.

I kept the fallback intentionally conservative (it doesn't guess a physical bay number it can't verify). If you'd prefer a plain numeric fallback, or want me to add a specific `ata2 -> bay N` entry for `UNAS_PRO` once the physical bay is confirmed, happy to adjust.

### Testing

Ran the collector on a UNAS Pro before/after. Before: 3 HDD entries. After: 4 — the previously-missing `ata2` disk now reports temperature, status and SMART as bay `ata2`, while the already-mapped bays (`3`, `6`, `7`) are unchanged. Compiles clean; no new lint findings.
